### PR TITLE
Update postgres version

### DIFF
--- a/app.json
+++ b/app.json
@@ -70,7 +70,7 @@
   "addons": [{
     "plan": "heroku-postgresql",
     "options": {
-      "version": "12"
+      "version": "16"
     }
   }],
   "buildpacks": [{


### PR DESCRIPTION
Due to:
```
We tried to create heroku-postgresq|:mini,
but received an error from the add-on
provider. Try the request again, or loga
support ticket and include this message:
Available versions are 13, 14, 15, 16 (the
default is 16)
```